### PR TITLE
Fix for PackedAvroSource issue

### DIFF
--- a/src/main/scala/scalding/avro/AvroSource.scala
+++ b/src/main/scala/scalding/avro/AvroSource.scala
@@ -62,7 +62,7 @@ object PackedAvroSource {
   = new PackedAvroSource[AvroType](paths)
 }
 
-class PackedAvroSource[AvroType : Manifest: AvroSchemaType : TupleConverter](paths: Seq[String])
+case class PackedAvroSource[AvroType : Manifest: AvroSchemaType : TupleConverter](paths: Seq[String])
 extends FixedPathSource(paths: _*) with PackedAvroFileScheme[AvroType]  {
    val schemaType = implicitly[AvroSchemaType[AvroType]]
    override val schema = schemaType.schema


### PR DESCRIPTION
This allows a JobTest formatted like below to be supported:

``` scala
JobTest("my.main.class")
   .arg("input", "myInput")
   .arg("output", "myOutput")
   .source(...)
   .sink[MyAvroObject](PackedAvroSource[MyAvroObject]("myOutput")) { 
      op => println(op.toList)
   }
   .runHadoop
   .finish
```
